### PR TITLE
use strict yaml parser mode to catch typos in certs.yaml

### DIFF
--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -90,7 +90,7 @@ func GenerateCertificates(output io.Writer, manifestFile, stateFile, destDir str
 	scanner.Split(splitByDocument)
 	for scanner.Scan() {
 		c := CertificateManifest{}
-		err := yaml.Unmarshal(scanner.Bytes(), &c)
+		err := yaml.UnmarshalStrict(scanner.Bytes(), &c)
 		if err != nil {
 			return fmt.Errorf("error while decoding: %s", err)
 		}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -122,8 +122,12 @@ func TestInvalidIssuer(t *testing.T) {
 }
 
 func TestInvalidManifest(t *testing.T) {
+	dir, err := ioutil.TempDir("", "certyaml-testsuite-*")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
 	var output bytes.Buffer
-	err := GenerateCertificates(&output, "testdata/non-existing-manifest.yaml", "", "")
+	err = GenerateCertificates(&output, "testdata/certs-invalid-field.yaml", path.Join(dir, "state.yaml"), dir)
 	assert.NotNil(t, err)
 }
 
@@ -133,6 +137,12 @@ func TestInvalidDestinationDir(t *testing.T) {
 	defer os.RemoveAll(dir)
 	var output bytes.Buffer
 	err = GenerateCertificates(&output, "testdata/certs-state-1.yaml", path.Join(dir, "state.yaml"), "non-existing-dir")
+	assert.NotNil(t, err)
+}
+
+func TestMissingManifest(t *testing.T) {
+	var output bytes.Buffer
+	err := GenerateCertificates(&output, "testdata/non-existing-manifest.yaml", "", "")
 	assert.NotNil(t, err)
 }
 

--- a/internal/manifest/testdata/certs-state-1.yaml
+++ b/internal/manifest/testdata/certs-state-1.yaml
@@ -12,7 +12,7 @@ sans:
 ---
 subject: cn=selfsigned-server
 ca: false
-key_usage:
+key_usages:
 - KeyEncipherment
 - DigitalSignature
 ---

--- a/internal/manifest/testdata/certs-state-2.yaml
+++ b/internal/manifest/testdata/certs-state-2.yaml
@@ -12,7 +12,7 @@ sans:
 ---
 subject: cn=selfsigned-server
 ca: false
-key_usage:
+key_usages:
 - KeyEncipherment
 - DigitalSignature
 ---


### PR DESCRIPTION
Unknown fields in `certs.yaml` were ignored, which makes it difficult to catch typos in the manifest file. This change enables strict YAML parsing mode which raises an error if unknown fields are given.