### PR TITLE
Replaced deprecated ioutil calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ install:
 	go install -v ./cmd/certyaml
 
 install-tools:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
-	go install github.com/securego/gosec/v2/cmd/gosec@v2.11.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0
+	go install github.com/securego/gosec/v2/cmd/gosec@v2.12.0
 
 update-modules:
 	go get -u -t ./... && go mod tidy

--- a/certificate_test.go
+++ b/certificate_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/url"
@@ -279,7 +278,7 @@ func TestWritingPEMFiles(t *testing.T) {
 		Issuer:  &ca,
 	}
 
-	dir, err := ioutil.TempDir("/tmp", "certyaml-unittest")
+	dir, err := os.MkdirTemp("/tmp", "certyaml-unittest")
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 

--- a/examples/go-api/main.go
+++ b/examples/go-api/main.go
@@ -65,6 +65,7 @@ func main() {
 
 				MinVersion: tls.VersionTLS13,
 			},
+			ReadHeaderTimeout: 10 * time.Second,
 		}
 
 		// Certs were provided in tls.Config so using "" as filenames.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tsaarni/certyaml
 
-go 1.13
+go 1.16
 
 require (
 	github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path"
@@ -83,7 +82,7 @@ func GenerateCertificates(output io.Writer, manifestFile, stateFile, destDir str
 	// Load stored state (if any) about previously created certificates and private keys.
 	// The state file is used to determine when certificates need to be re-created.
 	fmt.Fprintf(output, "Reading certificate state file: %s\n", stateFile)
-	data, _ := ioutil.ReadFile(filepath.Clean(stateFile))
+	data, _ := os.ReadFile(filepath.Clean(stateFile))
 	err = yaml.Unmarshal(data, &m.hashes)
 	if err != nil {
 		return fmt.Errorf("error while parsing certificate state file: %s", err)
@@ -172,7 +171,7 @@ func GenerateCertificates(output io.Writer, manifestFile, stateFile, destDir str
 		return err
 	}
 	fmt.Fprintf(output, "Writing state: %s\n", stateFile)
-	err = ioutil.WriteFile(stateFile, stateYaml, 0600)
+	err = os.WriteFile(stateFile, stateYaml, 0600)
 	if err != nil {
 		return fmt.Errorf("error while writing state: %s", err)
 	}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/url"
@@ -37,7 +36,7 @@ import (
 )
 
 func TestManifestHandling(t *testing.T) {
-	dir, err := ioutil.TempDir("", "certyaml-testsuite-*")
+	dir, err := os.MkdirTemp("", "certyaml-testsuite-*")
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -66,10 +65,10 @@ func TestManifestHandling(t *testing.T) {
 	}
 
 	// Check that files got generated.
-	fileInfos, err := ioutil.ReadDir(dir)
+	dirEntries, err := os.ReadDir(dir)
 	assert.Nil(t, err)
 	var gotFiles []string
-	for _, file := range fileInfos {
+	for _, file := range dirEntries {
 		gotFiles = append(gotFiles, file.Name())
 	}
 	sort.Strings(gotFiles)
@@ -77,7 +76,7 @@ func TestManifestHandling(t *testing.T) {
 }
 
 func TestStateHandling(t *testing.T) {
-	dir, err := ioutil.TempDir("", "certyaml-testsuite-*")
+	dir, err := os.MkdirTemp("", "certyaml-testsuite-*")
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -115,7 +114,7 @@ func TestStateHandling(t *testing.T) {
 }
 
 func TestInvalidIssuer(t *testing.T) {
-	dir, err := ioutil.TempDir("", "certyaml-testsuite-*")
+	dir, err := os.MkdirTemp("", "certyaml-testsuite-*")
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 	var output bytes.Buffer
@@ -124,7 +123,7 @@ func TestInvalidIssuer(t *testing.T) {
 }
 
 func TestInvalidManifest(t *testing.T) {
-	dir, err := ioutil.TempDir("", "certyaml-testsuite-*")
+	dir, err := os.MkdirTemp("", "certyaml-testsuite-*")
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -134,7 +133,7 @@ func TestInvalidManifest(t *testing.T) {
 }
 
 func TestInvalidDestinationDir(t *testing.T) {
-	dir, err := ioutil.TempDir("", "certyaml-testsuite-*")
+	dir, err := os.MkdirTemp("", "certyaml-testsuite-*")
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 	var output bytes.Buffer
@@ -149,7 +148,7 @@ func TestMissingManifest(t *testing.T) {
 }
 
 func TestParsingAllCertificateFields(t *testing.T) {
-	dir, err := ioutil.TempDir("", "certyaml-testsuite-*")
+	dir, err := os.MkdirTemp("", "certyaml-testsuite-*")
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -241,7 +240,7 @@ func TestParsingAllCertificateFields(t *testing.T) {
 }
 
 func TestRevocation(t *testing.T) {
-	dir, err := ioutil.TempDir("/tmp", "certyaml-unittest")
+	dir, err := os.MkdirTemp("/tmp", "certyaml-unittest")
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -278,7 +277,7 @@ func TestRevocation(t *testing.T) {
 }
 
 func TestInvalidRevocation(t *testing.T) {
-	dir, err := ioutil.TempDir("", "certyaml-testsuite-*")
+	dir, err := os.MkdirTemp("", "certyaml-testsuite-*")
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 	var output bytes.Buffer


### PR DESCRIPTION
- Replaced io/ioutil calls as they were deprecated in go 1.16
- Bumped golangci-lint and gosec
- Fixed new gosec finding in code examples