### PR TITLE
bump versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,11 +48,11 @@ jobs:
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
-        
+
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-        
+
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
@@ -61,7 +61,7 @@ jobs:
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
+    #   If the Autobuild fails above, remove it and uncomment the following three lines.
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
     # - run: |

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -13,12 +13,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.8.0
+        uses: aquasecurity/trivy-action@0.9.2
         with:
           scan-type: 'fs'
           format: 'sarif'
           output: 'trivy-results.sarif'
-          security-checks: 'vuln,secret,config'
+          scanners: 'vuln,secret,config'
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -20,15 +20,6 @@ jobs:
         go-version: 'stable'
       id: go
 
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
     - name: Checkout code
       uses: actions/checkout@v3
 
@@ -37,9 +28,9 @@ jobs:
         go get -v -t -d ./...
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v3
       with:
-          version: v1.50.1
+          version: v1.51.2
 
     - name: Build
       run: make build

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ install:
 	go install -v ./cmd/certyaml
 
 install-tools:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
-	go install github.com/securego/gosec/v2/cmd/gosec@v2.14.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
+	go install github.com/securego/gosec/v2/cmd/gosec@v2.15.0
 
 update-modules:
 	go get -u -t ./... && go mod tidy

--- a/crl_test.go
+++ b/crl_test.go
@@ -35,12 +35,12 @@ func TestRevocation(t *testing.T) {
 
 	crlBytes, err := crl.DER()
 	assert.Nil(t, err)
-	certList, err := x509.ParseCRL(crlBytes)
+	certList, err := x509.ParseRevocationList(crlBytes)
 	assert.Nil(t, err)
-	assert.Equal(t, 2, len(certList.TBSCertList.RevokedCertificates))
-	assert.Equal(t, "CN=ca", certList.TBSCertList.Issuer.String())
-	assert.Equal(t, big.NewInt(123), certList.TBSCertList.RevokedCertificates[0].SerialNumber)
-	assert.Equal(t, big.NewInt(456), certList.TBSCertList.RevokedCertificates[1].SerialNumber)
+	assert.Equal(t, 2, len(certList.RevokedCertificates))
+	assert.Equal(t, "CN=ca", certList.Issuer.String())
+	assert.Equal(t, big.NewInt(123), certList.RevokedCertificates[0].SerialNumber)
+	assert.Equal(t, big.NewInt(456), certList.RevokedCertificates[1].SerialNumber)
 }
 
 func TestInvalidSelfSigned(t *testing.T) {
@@ -88,10 +88,10 @@ func TestEmptyCRL(t *testing.T) {
 	crlBytes, err := crl.DER()
 	assert.Nil(t, err)
 
-	certList, err := x509.ParseCRL(crlBytes)
+	certList, err := x509.ParseRevocationList(crlBytes)
 	assert.Nil(t, err)
-	assert.Equal(t, 0, len(certList.TBSCertList.RevokedCertificates))
-	assert.Equal(t, "CN=ca", certList.TBSCertList.Issuer.String())
+	assert.Equal(t, 0, len(certList.RevokedCertificates))
+	assert.Equal(t, "CN=ca", certList.Issuer.String())
 
 	// Empty CRL with no issuer cannot be created.
 	crl = CRL{}

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.19
 
 require (
 	github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.8.2
 	github.com/tsaarni/x500dn v1.0.0
-	golang.org/x/mod v0.7.0
+	golang.org/x/mod v0.9.0
 	sigs.k8s.io/yaml v1.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -12,12 +12,12 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tsaarni/x500dn v1.0.0 h1:LvaWTkqRpse4VHBhB5uwf3wytokK4vF9IOyNAEyiA+U=
 github.com/tsaarni/x500dn v1.0.0/go.mod h1:QaHa3EcUKC4dfCAZmj8+ZRGLKukWgpGv9H3oOCsAbcE=
-golang.org/x/mod v0.7.0 h1:LapD9S96VoQRhi/GrNTqeBJFrUjs5UHCAtTlgwA5oZA=
-golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/mod v0.9.0 h1:KENHtAZL2y3NLMYZeHY9DW8HW8V+kQyJsY/V9JlKvCs=
+golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -257,11 +257,11 @@ func TestRevocation(t *testing.T) {
 	assert.NotNil(t, block)
 	assert.Equal(t, "X509 CRL", block.Type)
 	assert.Empty(t, rest)
-	certList, err := x509.ParseCRL(block.Bytes)
+	certList, err := x509.ParseRevocationList(block.Bytes)
 	assert.Nil(t, err)
-	assert.Equal(t, "CN=ca1", certList.TBSCertList.Issuer.String())
-	assert.Equal(t, 1, len(certList.TBSCertList.RevokedCertificates))
-	assert.Equal(t, big.NewInt(123), certList.TBSCertList.RevokedCertificates[0].SerialNumber)
+	assert.Equal(t, "CN=ca1", certList.Issuer.String())
+	assert.Equal(t, 1, len(certList.RevokedCertificates))
+	assert.Equal(t, big.NewInt(123), certList.RevokedCertificates[0].SerialNumber)
 
 	crlFile = path.Join(dir, "ca2-crl.pem")
 	pemBuffer, err = os.ReadFile(crlFile)
@@ -270,12 +270,12 @@ func TestRevocation(t *testing.T) {
 	assert.NotNil(t, block)
 	assert.Equal(t, "X509 CRL", block.Type)
 	assert.Empty(t, rest)
-	certList, err = x509.ParseCRL(block.Bytes)
+	certList, err = x509.ParseRevocationList(block.Bytes)
 	assert.Nil(t, err)
-	assert.Equal(t, "CN=ca2", certList.TBSCertList.Issuer.String())
-	assert.Equal(t, 2, len(certList.TBSCertList.RevokedCertificates))
-	assert.Equal(t, big.NewInt(123), certList.TBSCertList.RevokedCertificates[0].SerialNumber)
-	assert.Equal(t, big.NewInt(456), certList.TBSCertList.RevokedCertificates[1].SerialNumber)
+	assert.Equal(t, "CN=ca2", certList.Issuer.String())
+	assert.Equal(t, 2, len(certList.RevokedCertificates))
+	assert.Equal(t, big.NewInt(123), certList.RevokedCertificates[0].SerialNumber)
+	assert.Equal(t, big.NewInt(456), certList.RevokedCertificates[1].SerialNumber)
 }
 
 func TestInvalidRevocation(t *testing.T) {


### PR DESCRIPTION
Bump versions.
Replace new `x509.ParseRevocationList()` function instead of deprecated `x509.ParseCRL()`