### PR TITLE
Fix race when generation of certificate or CRL can be called from multiple goroutines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: check build
 
 test:
-	go test -v ./...
+	go test --race -v ./...
 
 check: test
 	golangci-lint run


### PR DESCRIPTION
This PR fixes a race condition that is triggered when `Certificate` or `CRL` get instantiated via multiple threads using the lazy initialization method. 

This happens in following scenario:

1. Global `Certificate` or `CRL` instance is created
2. Function that does lazy initialization of the object, such as `Certificate.PEM()`,  is called from multiple goroutines. This can happen when e.g. test cases that generate certificates are executed in parallel.

The fix does not attempt to cover regenerating certificate and key concurrently by calling `Certificate.Generate()` from multiple goroutines. The reason is that it would not be possible to synchronize "accessor" calls such as `Certificate.PEM()` with the re-generation, so synchronization would need to be on caller side for this use case. 

Fixes #47 