### PR TITLE
bump golang.org/x/mod v0.21.0 and golangci-lint v1.61.0

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.55.2
+          version: v1.61.0
           # Workaround for "file exists" errors while running tar.
           # golangci-lint-action conflicts with caching in setup-go
           skip-pkg-cache: true

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ install:
 	go install -v ./cmd/certyaml
 
 install-tools:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
 	go install github.com/securego/gosec/v2/cmd/gosec@v2.18.2
 
 update-modules:

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,14 @@
 module github.com/tsaarni/certyaml
 
-go 1.19
+go 1.22.0
+
+toolchain go1.22.4
 
 require (
 	github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08
 	github.com/stretchr/testify v1.9.0
 	github.com/tsaarni/x500dn v1.0.0
-	golang.org/x/mod v0.20.0
+	golang.org/x/mod v0.21.0
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tsaarni/x500dn v1.0.0 h1:LvaWTkqRpse4VHBhB5uwf3wytokK4vF9IOyNAEyiA+U=
 github.com/tsaarni/x500dn v1.0.0/go.mod h1:QaHa3EcUKC4dfCAZmj8+ZRGLKukWgpGv9H3oOCsAbcE=
-golang.org/x/mod v0.20.0 h1:utOm6MM3R3dnawAiJgn0y+xvuYRsm1RKM/4giyfDgV0=
-golang.org/x/mod v0.20.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
+golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Update golang.org/x/mod and golangci-lint

Replaces #63 which failed unit tests since CI now builds with Go v1.23.1 which does not work with golangci-lint v1.55.2 anymore, linter fails with errors like

```
  Error: c.GeneratedCert undefined (type CertificateManifest has no field or method GeneratedCert) (typecheck)
```

Upgrading golangci-lint to latest fixed the problem.