### PR TITLE
Added support for generating Ed25519 certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ Writing state: certs.state
 | --- | ----------- | -------- |
 | subject | Distinguished name for the certificate. `subject` is the only mandatory field and it must be unique. | `CN=Joe` |
 | sans | List of values for x509 Subject Alternative Name extension. | `DNS:www.example.com`, `IP:1.2.3.4`, `URI:https://www.example.com` |
-| key_type | Certificate key algorithm. Default value is `EC` (elliptic curve). | `EC` or `RSA` |
-| key_size | The key length in bits. Default value is 256 if `key_size` is not defined. | For key_type EC: `256`, `384`, `521`. For key_type RSA: `1024`, `2048`, `4096` |
+| key_type | Certificate key algorithm. Default value is `EC` (elliptic curve). | `EC`, `RSA` or `ED25519` |
+| key_size | The key length in bits. Default value is 256 if `key_size` is not defined. | For key_type EC: `256`, `384`, `521`. For key_type RSA: `1024`, `2048`, `4096`. For key_type ED25519: `256`. |
 | expires | Certificate NotAfter field is calculated by adding duration defined in `expires` to current time. Default value is 8760h (one year) if `expires` is not defined. `not_after` takes precedence over `expires`. | `1s`, `10m`, `1h` |
 | key_usages | List of values for x509 key usage extension. If `key_usages` is not defined, `CertSign` and `CRLSign` are set for CA certificates, `KeyEncipherment` and `DigitalSignature` are set for end-entity certificates. | `DigitalSignature`, `ContentCommitment`, `KeyEncipherment`, `DataEncipherment`, `KeyAgreement`, `CertSign`, `CRLSign`, `EncipherOnly`, `DecipherOnly` |
 | ext_key_usages | List of values for x509 extended key usage extension. Not set by default. | `Any`, `ServerAuth`, `ClientAuth`, `CodeSigning`, `EmailProtection`, `IPSECEndSystem`, `IPSECTunnel`, `IPSECUser`. `TimeStamping`, `OCSPSigning`, `MicrosoftServerGatedCrypto`, `NetscapeServerGatedCrypto`, `MicrosoftCommercialCodeSigning`, `MicrosoftKernelCodeSigning` |

--- a/certificate_test.go
+++ b/certificate_test.go
@@ -208,6 +208,10 @@ func TestInvalidKeySize(t *testing.T) {
 	input = Certificate{Subject: "CN=Joe", KeyType: KeyTypeRSA, KeySize: 1}
 	_, err = input.X509Certificate()
 	assert.NotNil(t, err)
+
+	input = Certificate{Subject: "CN=Joe", KeyType: KeyTypeEd25519, KeySize: 1}
+	_, err = input.X509Certificate()
+	assert.NotNil(t, err)
 }
 
 func TestPEM(t *testing.T) {

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -219,6 +219,8 @@ func (m *Manifest) processCertificate(c *CertificateManifest) error {
 			c.KeyType = api.KeyTypeEC
 		case "RSA":
 			c.KeyType = api.KeyTypeRSA
+		case "ED25519":
+			c.KeyType = api.KeyTypeEd25519
 		default:
 			return fmt.Errorf("key_type contains invalid value: %s", c.KeyTypeAsString)
 		}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -239,6 +239,16 @@ func TestParsingAllCertificateFields(t *testing.T) {
 	assert.Empty(t, got.IPAddresses)
 
 	assert.Equal(t, big.NewInt(123), got.SerialNumber)
+
+	// Check fields Ee25519  end-entity cert.
+	tlsCert, err = tls.LoadX509KeyPair(path.Join(dir, "ed25519-cert.pem"), path.Join(dir, "ed25519-cert-key.pem"))
+	assert.Nil(t, err)
+	got, err = x509.ParseCertificate(tlsCert.Certificate[0])
+	assert.Nil(t, err)
+
+	assert.Equal(t, "ed25519-cert", got.Issuer.CommonName)
+	assert.Equal(t, "ed25519-cert", got.Subject.CommonName)
+	assert.Equal(t, x509.Ed25519, got.PublicKeyAlgorithm)
 }
 
 func TestRevocation(t *testing.T) {

--- a/internal/manifest/testdata/certs-test-all-fields.yaml
+++ b/internal/manifest/testdata/certs-test-all-fields.yaml
@@ -42,3 +42,6 @@ key_size: 256
 not_before: 2020-01-01T09:00:00Z
 expires: 1h
 serial: 123
+---
+subject: cn=ed25519-cert
+key_type: ED25519


### PR DESCRIPTION
This change introduces new key type

```yaml
subject: cn=mycert
key_type: ED25519
```

Fixes #65