### PR TITLE
Added support for setting CRL distribution point URI

### DIFF
--- a/certificate.go
+++ b/certificate.go
@@ -93,6 +93,10 @@ type Certificate struct {
 	// If not set, the default value is current time in nanoseconds.
 	SerialNumber *big.Int `json:"-" hash:"-"`
 
+	// CRLDistributionPoint defines the URI for downloading the CRL for this certificate.
+	// Not set by default.
+	CRLDistributionPoints []string `json:"crl_distribution_points"`
+
 	// GeneratedCert is a pointer to the generated certificate and private key.
 	// It is automatically set after calling any of the Certificate functions.
 	GeneratedCert *tls.Certificate `json:"-" hash:"-"`
@@ -200,11 +204,11 @@ func (c *Certificate) WritePEM(certFile, keyFile string) error {
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(certFile, cert, 0600)
+	err = os.WriteFile(certFile, cert, 0o600)
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(keyFile, key, 0600)
+	err = os.WriteFile(keyFile, key, 0o600)
 	if err != nil {
 		return err
 	}
@@ -341,6 +345,7 @@ func (c *Certificate) Generate() error {
 		ExtKeyUsage:           c.ExtKeyUsage,
 		BasicConstraintsValid: *c.IsCA,
 		IsCA:                  *c.IsCA,
+		CRLDistributionPoints: c.CRLDistributionPoints,
 	}
 
 	for _, san := range c.SubjectAltNames {

--- a/certificate_test.go
+++ b/certificate_test.go
@@ -44,7 +44,6 @@ func TestSubjectAltName(t *testing.T) {
 	input := Certificate{Subject: "CN=Joe", SubjectAltNames: []string{"DNS:host.example.com", "URI:http://www.example.com", "IP:1.2.3.4"}}
 	got, err := input.X509Certificate()
 	assert.Nil(t, err)
-	assert.Nil(t, err)
 	assert.Equal(t, "Joe", got.Subject.CommonName)
 	assert.Equal(t, "host.example.com", got.DNSNames[0])
 	assert.Equal(t, url.URL{Scheme: "http", Host: "www.example.com"}, *got.URIs[0])
@@ -422,4 +421,11 @@ func TestParallelCertificateLazyInitialization(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestCRLDistributionPoint(t *testing.T) {
+	input := Certificate{Subject: "CN=Joe", CRLDistributionPoints: []string{"http://example.com/crl.pem"}}
+	got, err := input.X509Certificate()
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"http://example.com/crl.pem"}, got.CRLDistributionPoints)
 }

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -213,6 +213,8 @@ func TestParsingAllCertificateFields(t *testing.T) {
 	assert.Equal(t, expectedURL, got.URIs[0])
 	assert.True(t, got.IPAddresses[0].Equal(expectedIP))
 
+	assert.Equal(t, []string{"http://ca1.example.com/crl", "http://ca2.example.com/crl"}, got.CRLDistributionPoints)
+
 	// Check fields from second end-entity cert.
 	tlsCert, err = tls.LoadX509KeyPair(path.Join(dir, "ec-cert.pem"), path.Join(dir, "ec-cert-key.pem"))
 	assert.Nil(t, err)

--- a/internal/manifest/testdata/certs-test-all-fields.yaml
+++ b/internal/manifest/testdata/certs-test-all-fields.yaml
@@ -36,6 +36,9 @@ issuer: cn=ca
 ca: true
 not_before: 2020-01-01T09:00:00Z
 not_after: 2030-01-01T09:00:00Z
+crl_distribution_points:
+- http://ca1.example.com/crl
+- http://ca2.example.com/crl
 ---
 subject: cn=ec-cert
 key_size: 256


### PR DESCRIPTION
Adds new field `Certificate.CRLDistributionPoints` which is an array of strings.
When defined, CRL Distribution Points extension will be added to the certificate.

Example

```yaml
subject: cn=server
crl_distribution_points:
- http://ca1.example.com/crl.pem
- http://ca2.example.com/crl.pem
```

The generated certificate will have following extension added:

```console
Certificate:
    Data:
        X509v3 extensions:
            X509v3 CRL Distribution Points:
                Full Name:
                  URI:http://ca1.example.com/crl.pem
                Full Name:
                  URI:http://ca2.example.com/crl.pem
```

Fixes #23