### PR TITLE
Replace golangci-lint action and dirhash module

### DIFF
--- a/.github/actions/golangci-lint/action.yaml
+++ b/.github/actions/golangci-lint/action.yaml
@@ -1,0 +1,18 @@
+# This action runs golangci-lint using Makefile.
+# It ensures the same version of golangci-lint is used in CI as in local development.
+name: golangci-lint
+description: 'Run golangci-lint'
+inputs:
+  working-directory:
+    description: 'Working directory'
+    required: false
+    default: '.'
+runs:
+  using: 'composite'
+  steps:
+    - name: Run golangci-lint
+      run: |
+        echo "::add-matcher::${{ inputs.working-directory }}/.github/actions/golangci-lint/matcher.json"
+        make lint
+        echo "::remove-matcher owner=golangci-lint::"
+      shell: bash

--- a/.github/actions/golangci-lint/matcher.json
+++ b/.github/actions/golangci-lint/matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "golangci-lint-colored-line-number",
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^([^:]+):(\\d+):(?:(\\d+):)?\\s+(.+ \\(.+\\))$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
 jobs:
   build:
     name: Build

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -21,18 +21,8 @@ jobs:
           go-version: "stable"
         id: go
 
-      - name: Get dependencies
-        run: |
-          go get -v -t -d ./...
-
-      # https://github.com/golangci/golangci-lint-action
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.61.0
-          # Workaround for "file exists" errors while running tar.
-          # golangci-lint-action conflicts with caching in setup-go
-          skip-pkg-cache: true
+        uses: ./.github/actions/golangci-lint
 
       - name: Build
         run: make build

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@
 # Local History for Visual Studio Code
 .history/
 
-./certyaml
+certyaml

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,14 @@
+linters:
+# https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - gosec
+    - gofmt
+    - goimports
+    - misspell
+    - revive

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,18 @@
 all: check build
 
+check: test lint
+
 test:
 	go test --race -v ./...
 
-check: test
-	golangci-lint run
-	gosec -quiet ./...
+lint:
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0 run
 
 build:
 	go build -v ./cmd/certyaml
 
 install:
 	go install -v ./cmd/certyaml
-
-install-tools:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
-	go install github.com/securego/gosec/v2/cmd/gosec@v2.18.2
 
 update-modules:
 	go get -u -t ./... && go mod tidy

--- a/certificate_test.go
+++ b/certificate_test.go
@@ -323,17 +323,17 @@ func TestWritingPEMFiles(t *testing.T) {
 func TestRegenerate(t *testing.T) {
 	cert := Certificate{Subject: "CN=Joe"}
 
-	old, err := cert.TLSCertificate()
+	older, err := cert.TLSCertificate()
 	assert.Nil(t, err)
 
 	err = cert.Generate()
 	assert.Nil(t, err)
 
-	new, err := cert.TLSCertificate()
+	newer, err := cert.TLSCertificate()
 	assert.Nil(t, err)
 
-	assert.NotEqual(t, old.Certificate, new.Certificate)
-	assert.NotEqual(t, old.PrivateKey, new.PrivateKey)
+	assert.NotEqual(t, older.Certificate, newer.Certificate)
+	assert.NotEqual(t, older.PrivateKey, newer.PrivateKey)
 }
 
 func TestSerial(t *testing.T) {

--- a/crl_test.go
+++ b/crl_test.go
@@ -109,7 +109,7 @@ func TestParallelCRLLazyInitialization(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
-		go func(cert *Certificate) {
+		go func(_ *Certificate) {
 			defer wg.Done()
 			_, err := crl.DER()
 			assert.Nil(t, err)

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,11 @@
 module github.com/tsaarni/certyaml
 
-go 1.22.0
-
-toolchain go1.22.4
+go 1.19
 
 require (
 	github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08
 	github.com/stretchr/testify v1.9.0
 	github.com/tsaarni/x500dn v1.0.0
-	golang.org/x/mod v0.21.0
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tsaarni/x500dn v1.0.0 h1:LvaWTkqRpse4VHBhB5uwf3wytokK4vF9IOyNAEyiA+U=
 github.com/tsaarni/x500dn v1.0.0/go.mod h1:QaHa3EcUKC4dfCAZmj8+ZRGLKukWgpGv9H3oOCsAbcE=
-golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
-golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
This change replaces `golangci-lint` github action with a custom action that runs `make lint`. This will make sure github runs same version as what is used locally on development machine, without requiring to update version number in two places.

The update also replaces the use of `dirhash.HashDir()` in the test suite to prevent adding `golang.org/x/mod` and therefore also go1.22 as mandatory dependencies of certyaml.

