### PR TITLE
Added convenience getters for certificate and private key for single-value use

### DIFF
--- a/certificate.go
+++ b/certificate.go
@@ -190,6 +190,28 @@ func (c *Certificate) PEM() (cert []byte, key []byte, err error) {
 	return
 }
 
+// CertPEM returns the certificate as a PEM buffer.
+// This method is useful in single-value context, for example when populating struct field.
+// Unlike the PEM() method, which handles errors, this method will panic if an error occurs.
+func (c *Certificate) CertPEM() []byte {
+	cert, _, err := c.PEM()
+	if err != nil {
+		panic(err)
+	}
+	return cert
+}
+
+// KeyPEM returns the private key as a PEM buffer.
+// This method is useful in single-value context, for example when populating struct field.
+// Unlike the PEM() method, which handles errors, this method will panic if an error occurs.
+func (c *Certificate) KeyPEM() []byte {
+	_, key, err := c.PEM()
+	if err != nil {
+		panic(err)
+	}
+	return key
+}
+
 // WritePEM writes the Certificate as certificate and private key PEM files.
 // Complete certificate chain (up to but not including root) is included for end-entity certificates.
 // A key pair and certificate will be generated at first call of any Certificate functions.

--- a/certificate_test.go
+++ b/certificate_test.go
@@ -429,3 +429,11 @@ func TestCRLDistributionPoint(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"http://example.com/crl.pem"}, got.CRLDistributionPoints)
 }
+
+func TestConvenienceGetters(t *testing.T) {
+	input := Certificate{Subject: "CN=Joe"}
+	cert, key, err := input.PEM()
+	assert.Nil(t, err)
+	assert.Equal(t, cert, input.CertPEM())
+	assert.Equal(t, key, input.KeyPEM())
+}


### PR DESCRIPTION
Added `Certificate.CertPEM()` and `Certificate.KeyPEM()` methods as convenience methods to return the certificate and key in PEM format for using in single-value context, for example when populating struct field. They are alternative to the `Certificate.PEM()` method, which returns the certificate, key, and error.
