### PR TITLE
Have dependabot update codeql-action in a group to avoid errors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,16 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"


### PR DESCRIPTION
Separate dependabot updates for `github.com/github/codeql-action/{init,autobuild,analyze}` cause CI failures like

```
Error: Loaded a configuration file for version '4.37.1', but running version '4.37.4'
```

Group the bumps together to avoid mixing versions in a single run.

Also, configure Dependabot cooldown period for the project to reduce the chance of falling victim of a supply chain attack.